### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt": "~0.4.2",
     "grunt-contrib-coffee": "~0.10.0",
     "moment-timezone": "~0.4.0",
-    "request": "~2.33.0",
+    "request": "~2.74.0",
     "underscore": "~1.5.2",
     "xml2js": "~0.4.1"
   },


### PR DESCRIPTION
shipit currently has a 7 vulnerable dependency paths, introducing 5 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
- [Denial of Service (Event Loop Blocking)](https://snyk.io/vuln/npm:qs:20140806-1) vulnerability in the `qs` dependency.
- [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) vulnerability in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/sailrish/shipit) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `grunt` dependency as well.

Stay Secure,
The Snyk Team
